### PR TITLE
updated compileSdkVersion and targetSdkVersion version numbers

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 23
+    compileSdkVersion 28
     buildToolsVersion "23.0.1"
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 22
+        targetSdkVersion 27
         versionCode 2
         versionName "1.1"
         ndk {


### PR DESCRIPTION
I updated the version numbers for `compileSdkVersion` to `28` and `targetSdkVersion` to `27` in order to resolve the `com.android.builder.internal.aapt.v2.Aapt2Exception` error that users have been getting.